### PR TITLE
Add support for Django 4

### DIFF
--- a/error_tracker/__init__.py
+++ b/error_tracker/__init__.py
@@ -6,7 +6,7 @@
 #    :license: BSD-3-Clause
 #
 
-__version__ = '2.1.0'
+__version__ = '3.0.0'
 __author__ = 'Sonu Kumar'
 __email__ = 'sonunitw12@gmail.com'
 

--- a/error_tracker/django/templates/error_tracker/base.html
+++ b/error_tracker/django/templates/error_tracker/base.html
@@ -38,7 +38,7 @@
 		<div class="container">
 			{% block header_block %}
 				<h2 class="text-center mb-5 mt-3">
-					<a href="{% url 'view_errors' %}" class="text-dark home-link">{% trans 'Errors Seen' %}</a>
+					<a href="{% url 'error_tracker:view_errors' %}" class="text-dark home-link">{% trans 'Errors Seen' %}</a>
 				</h2>
 			{% endblock %}
 			{% block content_block %}

--- a/error_tracker/django/templates/error_tracker/partials/partial_table.html
+++ b/error_tracker/django/templates/error_tracker/partials/partial_table.html
@@ -4,7 +4,7 @@
             <td>{{ error.host }}</td>
             <td width="2%">{{ error.method }}</td>
             <td>
-                <a class="view-link" href="{% url 'view_error' rhash=error.hash %}">
+                <a class="view-link" href="{% url 'error_tracker:view_error' rhash=error.hash %}">
                     {{ error.path|truncatechars:30 }}
                 </a>
             </td>
@@ -12,7 +12,7 @@
             <td>{{ error.last_seen }}</td>
             <td>{{ error.count }}</td>
             <td>
-                <a href="{% url 'delete_error' rhash=error.hash %}"
+                <a href="{% url 'error_tracker:delete_error' rhash=error.hash %}"
                    class="delete btn btn-danger btn-sm">{%trans 'Delete' %}</a>
             </td>
         </tr>

--- a/error_tracker/django/urls.py
+++ b/error_tracker/django/urls.py
@@ -6,11 +6,12 @@
 #    :license: BSD-3-Clause
 #
 
-from django.conf.urls import url
+from django.urls import path
 from .views import detail, view_list, delete_exception
 
+app_name = 'error_tracker'
 urlpatterns = [
-    url(r'^$', view_list, name="view_errors"),
-    url(r'^(?P<rhash>[\w-]+)/delete$', delete_exception, name='delete_error'),
-    url(r'^(?P<rhash>[\w-]+)$', detail, name='view_error'),
+    path('', view_list, name="view_errors"),
+    path('<rhash>/delete', delete_exception, name='delete_error'),
+    path('<rhash>', detail, name='view_error'),
 ]

--- a/error_tracker/django/views.py
+++ b/error_tracker/django/views.py
@@ -42,13 +42,14 @@ def view_list(request):
     error = False
     errors = model.get_exceptions_per_page(**query)
    
-    next_url = reverse('view_errors') + "?page=" + str(errors.next_num) \
+    next_url = reverse('error_tracker:view_errors') + "?page=" + str(errors.next_num) \
         if errors.has_next else None
 
-    prev_url = reverse('view_errors') + "?page=" + str(errors.prev_num) \
+    prev_url = reverse('error_tracker:view_errors') + "?page=" + str(errors.prev_num) \
         if errors.has_prev else None
 
-    if request.is_ajax() or request.GET.get('ajax_partial'):
+    is_ajax = request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
+    if is_ajax or request.GET.get('ajax_partial'):
         table = render_to_string('error_tracker/partials/partial_table.html', {
             'errors': errors,
         })
@@ -75,7 +76,7 @@ def delete_exception(request, rhash):
     :return: redirect back to home page
     """
     model.delete_entity(rhash)
-    return redirect(reverse('view_errors'))
+    return redirect(reverse('error_tracker:view_errors'))
 
 
 @require_GET

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/tests/DjangoTest/DjangoTest/drf_urls.py
+++ b/tests/DjangoTest/DjangoTest/drf_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import path, include
 from django.contrib import admin
 from rest_framework import routers
 from error_tracker.django import urls
@@ -9,11 +9,11 @@ router = routers.DefaultRouter()
 router.register(r'users', UserViewSet)
 
 urlpatterns = [
-    url('admin/', admin.site.urls),
-    url("dev/", include(urls)),
-    url(r'^$', views.index),
-    url(r'^value-error$', views.value_error),
-    url(r'^post-view$', views.post_view),
-    url(r'^', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls'))
+    path('admin/', admin.site.urls),
+    path('dev/', include(urls)),
+    path('', views.index),
+    path('value-error', views.value_error),
+    path('post-view', views.post_view),
+    path('', include(router.urls)),
+    path('api-auth/', include('rest_framework.urls'))
 ]

--- a/tests/DjangoTest/DjangoTest/urls.py
+++ b/tests/DjangoTest/DjangoTest/urls.py
@@ -13,15 +13,15 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import path, include
 from django.contrib import admin
 from error_tracker.django import urls
 from core import views
 
 urlpatterns = [
-    url('admin/', admin.site.urls),
-    url("dev/", include(urls)),
-    url(r'^$', views.index),
-    url(r'^value-error$', views.value_error),
-    url(r'^post-view$', views.post_view),
+    path('admin/', admin.site.urls),
+    path('dev/', include(urls)),
+    path('', views.index),
+    path('value-error', views.value_error),
+    path('post-view', views.post_view),
 ]


### PR DESCRIPTION
Django 4.0 no longer contains the url method for defining routes.
This pull request defines the routers using the more modern path method, and defines the app_name to allow for URLs namespaces.